### PR TITLE
Erstelle Basisimage mit Mender integration

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,0 +1,2 @@
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"

--- a/recipes-core/images/formenheizung-image.bb
+++ b/recipes-core/images/formenheizung-image.bb
@@ -1,0 +1,4 @@
+#include recipes-core/images/rpi-hwup-image.bb
+include recipes-core/images/core-image-minimal.bb
+
+IMAGE_INSTALL += "packagegroup-base"

--- a/recipes-mender/mender/mender_%.bbappend
+++ b/recipes-mender/mender/mender_%.bbappend
@@ -1,0 +1,2 @@
+SYSTEMD_AUTO_ENABLE = "disable"
+


### PR DESCRIPTION
Das Basisimage enthält nur genug Funktionalität, um das Image auf dem Raspberry Pi 3 startbar zu machen.

Mender ist integriert, um das Image zur aktualisieren.